### PR TITLE
Add search_filter_provider to select components

### DIFF
--- a/leptonic/src/select.rs
+++ b/leptonic/src/select.rs
@@ -78,6 +78,7 @@ pub fn Select<O>(
     #[prop(into)] set_selected: Out<O>,
     #[prop(into)] search_text_provider: Callback<O, String>,
     #[prop(into)] render_option: ViewCallback<O>,
+    #[prop(into, optional)] search_filter_provider: Option<Callback<(String, Vec<O>), Vec<O>>>,
     #[prop(into, optional)] autofocus_search: Option<Signal<bool>>,
     #[prop(into, optional)] class: Option<AttributeValue>,
     #[prop(into, optional)] style: Option<AttributeValue>,
@@ -107,19 +108,21 @@ where
 
     let (search, set_search) = create_signal(String::new());
 
+    let search_filter_provider = search_filter_provider
+        .unwrap_or(Callback::new(move |(s, o) : (String, Vec<O>)| {
+            let lowercased_search = s.to_lowercase();
+            o.into_iter()
+                .filter(|it| {
+                    search_text_provider
+                        .call(it.clone())
+                        .to_lowercase()
+                        .contains(lowercased_search.as_str())
+                })
+                .collect::<Vec<O>>()
+        }));
+
     let filtered_options = create_memo(move |_| {
-        let lowercased_search = search.get().to_lowercase();
-        stored_options
-            .get_value()
-            .get()
-            .into_iter()
-            .filter(|it| {
-                search_text_provider
-                    .call(it.clone())
-                    .to_lowercase()
-                    .contains(lowercased_search.as_str())
-            })
-            .collect::<Vec<O>>()
+        search_filter_provider.call((search.get(), stored_options.get_value().get()))
     });
 
     let has_options = create_memo(move |_| !filtered_options.with(Vec::is_empty));
@@ -313,6 +316,7 @@ pub fn OptionalSelect<O>(
     #[prop(into)] search_text_provider: Callback<O, String>,
     #[prop(into)] render_option: ViewCallback<O>,
     #[prop(into)] allow_deselect: MaybeSignal<bool>,
+    #[prop(into, optional)] search_filter_provider: Option<Callback<(String, Vec<O>), Vec<O>>>,
     #[prop(into, optional)] autofocus_search: Option<Signal<bool>>,
     #[prop(into, optional)] class: Option<AttributeValue>,
     #[prop(into, optional)] style: Option<AttributeValue>,
@@ -342,19 +346,21 @@ where
 
     let (search, set_search) = create_signal(String::new());
 
+    let search_filter_provider = search_filter_provider
+        .unwrap_or(Callback::new(move |(s, o) : (String, Vec<O>)| {
+            let lowercased_search = s.to_lowercase();
+            o.into_iter()
+                .filter(|it| {
+                    search_text_provider
+                        .call(it.clone())
+                        .to_lowercase()
+                        .contains(lowercased_search.as_str())
+                })
+                .collect::<Vec<O>>()
+        }));
+
     let filtered_options = create_memo(move |_| {
-        let lowercased_search = search.get().to_lowercase();
-        stored_options
-            .get_value()
-            .get()
-            .into_iter()
-            .filter(|it| {
-                search_text_provider
-                    .call(it.clone())
-                    .to_lowercase()
-                    .contains(lowercased_search.as_str())
-            })
-            .collect::<Vec<_>>()
+        search_filter_provider.call((search.get(), stored_options.get_value().get()))
     });
 
     let has_options = create_memo(move |_| !filtered_options.with(Vec::is_empty));
@@ -571,6 +577,7 @@ pub fn Multiselect<O>(
     #[prop(into)] set_selected: Out<Vec<O>>,
     #[prop(into)] search_text_provider: Callback<O, String>,
     #[prop(into)] render_option: ViewCallback<O>,
+    #[prop(into, optional)] search_filter_provider: Option<Callback<(String, Vec<O>), Vec<O>>>,
     #[prop(into, optional)] autofocus_search: Option<Signal<bool>>,
     #[prop(into, optional)] class: Option<AttributeValue>,
     #[prop(into, optional)] style: Option<AttributeValue>,
@@ -600,19 +607,21 @@ where
 
     let (search, set_search) = create_signal(String::new());
 
+    let search_filter_provider = search_filter_provider
+        .unwrap_or(Callback::new(move |(s, o) : (String, Vec<O>)| {
+            let lowercased_search = s.to_lowercase();
+            o.into_iter()
+                .filter(|it| {
+                    search_text_provider
+                        .call(it.clone())
+                        .to_lowercase()
+                        .contains(lowercased_search.as_str())
+                })
+                .collect::<Vec<O>>()
+        }));
+
     let filtered_options = create_memo(move |_| {
-        let lowercased_search = search.get().to_lowercase();
-        stored_options
-            .get_value()
-            .get()
-            .into_iter()
-            .filter(|it| {
-                search_text_provider
-                    .call(it.clone())
-                    .to_lowercase()
-                    .contains(lowercased_search.as_str())
-            })
-            .collect::<Vec<_>>()
+        search_filter_provider.call((search.get(), stored_options.get_value().get()))
     });
 
     let has_options = create_memo(move |_| !filtered_options.with(Vec::is_empty));


### PR DESCRIPTION
This pull request adds a new optional property called `search_filter_provider` to the select components. Currently the filtering is hardcoded to check if items contain the lowercase search string. This can now be customised.

Here is an example of filtering with `.starts_with` instead of `.contains` and only showing the top 20 results (important when your Vec is huge):

```
<OptionalSelect
    options=systems_data
    search_text_provider=move |o : System| o.name
    search_filter_provider=move |(s, o) : (String, Vec<System>)| {
        let lowercased_search = s.to_lowercase();
        o.into_iter()
            .filter(|it| {
                it.name
                    .to_lowercase()
                    .starts_with(lowercased_search.as_str())
            })
            .take(20)
            .collect::<Vec<_>>()
    }
    render_option=move |o : System| format!("{}", o.name)
    selected=move || selected_opt.get()
    set_selected=move |v| set_selected_opt.set(v)
/>
```

One known issue is that specifying `search_filter_provider` makes `search_text_provider` redundant, but you still need to specify `search_text_provider`. I kept it that way for backwards compatibility.

This is my first pull request. I'm open to feedback if you'd prefer I change anything.