### PR TITLE
Fill the entire viewport with the themed background

### DIFF
--- a/leptonic/src/root.rs
+++ b/leptonic/src/root.rs
@@ -180,7 +180,7 @@ where
         <ThemeProvider theme=create_signal_ls("theme", default_theme)>
             <ToastRoot>
                 <ModalRoot>
-                    <Box style="min-height: 100%; min-width: 100%; display: flex; flex-direction: column;">
+                    <Box style="min-height: 100vh; min-width: 100vh; display: flex; flex-direction: column;">
                         { children() }
                     </Box>
                 </ModalRoot>

--- a/leptonic/src/root.rs
+++ b/leptonic/src/root.rs
@@ -180,7 +180,7 @@ where
         <ThemeProvider theme=create_signal_ls("theme", default_theme)>
             <ToastRoot>
                 <ModalRoot>
-                    <Box style="min-height: 100vh; min-width: 100vh; display: flex; flex-direction: column;">
+                    <Box style="min-height: 100vh; min-width: 100%; display: flex; flex-direction: column;">
                         { children() }
                     </Box>
                 </ModalRoot>

--- a/leptonic/src/theme.rs
+++ b/leptonic/src/theme.rs
@@ -55,7 +55,7 @@ where
     view! {
         <leptonic-theme-provider
             data-theme=move || theme.get().name()
-            style="height: 100%; width: auto; display: contents;"
+            style="min-height: 100vh; min-width: 100vh; width: auto; display: contents;"
         >
             { children() }
         </leptonic-theme-provider>


### PR DESCRIPTION
With the current styling on leptonic-theme-provider and leptonic-box, I found that I couldn't get the themed background to grow with the overflow content. I tried modifying the html and body styling to have min-height/height as either 100% or 100vh, but neither helped. The only hack that fixed it was:

```
leptonic-theme-provider, leptonic-box {
    min-height: 100vh !important;
    min-width: 100vw !important;
}
```

This pull request should hopefully fix the root cause of the problem.