### PR TITLE
docs: Remove (ignored) parameter from "title" closure of Alert

### DIFF
--- a/examples/book/src/pages/documentation/alert.rs
+++ b/examples/book/src/pages/documentation/alert.rs
@@ -10,7 +10,7 @@ pub fn PageAlert() -> impl IntoView {
 
         <Code>
             {indoc!(r#"
-                <Alert variant=AlertVariant::Success title=|_| "Success".into_view()>"Action completed."</Alert>
+                <Alert variant=AlertVariant::Success title=|| "Success".into_view()>"Action completed."</Alert>
             "#)}
         </Code>
 


### PR DESCRIPTION
Very minor, I just noticed it when pasting the code and the line clearly does not exactly mirror the actual code below that it should represent.

Feel free to ignore this or reject it, just something very minor that popped up when I read through the docs.