### PR TITLE
Fix gap property for Grid in documentation

### DIFF
--- a/examples/book-ssr/src/pages/documentation/components/layout/grid.rs
+++ b/examples/book-ssr/src/pages/documentation/components/layout/grid.rs
@@ -15,7 +15,7 @@ pub fn PageGrid() -> impl IntoView {
 
             <Code>
                 {indoc!(r#"
-                    <Grid spacing=Size::Em(0.6)>
+                    <Grid gap=Size::Em(0.6)>
                         <Row>
                             <Col md=3 sm=4 xs=6>
                                 <Skeleton animated=false>"Item 1"</Skeleton>


### PR DESCRIPTION
The documentation for `Grid` component uses property `spacing` instead of `gap`.