### PR TITLE
Relax dependency on time crate (fixes #76)

### DIFF
--- a/leptonic/Cargo.toml
+++ b/leptonic/Cargo.toml
@@ -37,7 +37,7 @@ serde = "1.0.196"
 serde-wasm-bindgen = "0.6.3"
 serde_json = "1.0.113"
 strum = { version = "0.26.1", features = ["derive"] }
-time = { version = "=0.3.31", features = [
+time = { version = "0.3.31", features = [
     "wasm-bindgen",
     "macros",
     "serde",


### PR DESCRIPTION
This PR is just a single commit on top of v0.5.0, with the aim of unblocking users with a v0.5.1 until work resumes on `main`.  It would belong to a `leptonic-0.5` branch of sorts for producing 0.5.x maintenance releases.